### PR TITLE
Add compile option to break on assert instead of aborting

### DIFF
--- a/src/rx/core/assert.cpp
+++ b/src/rx/core/assert.cpp
@@ -2,6 +2,14 @@
 #include <stdarg.h> // va_{list,start,end,copy}
 #include <stdio.h> // vsnprintf
 
+#if defined(RX_BREAK_ON_ASSERT)
+#if defined(RX_PLATFORM_WINDOWS)
+#include <Windows.h>   // DebugBreak
+#elif defined(RX_PLATFORM_LINUX)
+#include <signal.h> // raise, SIGINT
+#endif
+#endif
+
 #include "rx/core/log.h" // RX_LOG, rx::log
 #include "rx/core/abort.h" // rx::abort
 
@@ -31,7 +39,15 @@ void assert_fail(const char* _expression, const char* _file,
   logger(log::level::k_error, "Assertion failed: %s (%s:%d %s) \"%s\"",
     _expression, _file, _line, _function, utility::move(contents));
 
+#if defined(RX_BREAK_ON_ASSERT)
+#if defined(RX_PLATFORM_WINDOWS)
+  DebugBreak();
+#elif defined(RX_PLATFORM_LINUX)
+  raise(SIGINT);
+#endif
+#else
   abort(contents.data());
+#endif
 }
 
 } // namespace rx


### PR DESCRIPTION
If you define the symbol `RX_BREAK_ON_ASSERT`, Rex will raise a breakpoint on a failed assert instead of `abort`ing